### PR TITLE
setup.py was missing license field

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
     description = "Whole Architecture Verification",
     author = "P Henderson and M J Henderson",
     author_email = "matthew.james.henderson@gmail.com",
+    license = "LGPL",
     url = "http://packages.python.org/Wave/",  
     download_url = "http://pypi.python.org/pypi/Wave/",
     keywords = "wave verification",


### PR DESCRIPTION
While it has no effect on the actual license or the usability of this library, it hinders the use of tools like `pip-licenses`.