### PR TITLE
Prepare first release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Matthew Henderson
+Copyright (c) 2024 Matthew Henderson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
-# Wave (development version)
+# wharve (development version)
 
-# Wave (v0.1.0)
+# wharve (0.1.0)
 
+* Rename old Wave project.
 * A fresh start.
-* Using poetry.
+* Implementation of dot join and circle-dot join.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wharve"
-version = "0.0.0"
+version = "0.1.0"
 description = "Whole architecture verification."
 authors = ["Matthew Henderson <matthew.james.henderson@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Even though the package is basically empty this seems like the simplest (only?) way of reserving the package name on PyPi.